### PR TITLE
Add default tableViewController editing / delete support

### DIFF
--- a/FileBrowser.podspec
+++ b/FileBrowser.podspec
@@ -8,7 +8,7 @@
 
 Pod::Spec.new do |s|
   s.name             = "FileBrowser"
-  s.version          = "0.2.0"
+  s.version          = "0.2.1"
   s.summary          = "Powerful iOS file browser in Swift."
 
 # This description is used to generate tags and improve search results.

--- a/FileBrowser/FBFile.swift
+++ b/FileBrowser/FBFile.swift
@@ -23,6 +23,18 @@ open class FBFile: NSObject {
     // FBFileType
     open let type: FBFileType
     
+    open func delete()
+    {
+        do
+        {
+            try FileManager.default.removeItem(at: self.filePath)
+        }
+        catch
+        {
+            print("An error occured when trying to delete file:\(self.filePath) Error:\(error)")
+        }
+    }
+    
     /**
      Initialize an FBFile object with a filePath
      

--- a/FileBrowser/FileBrowser.swift
+++ b/FileBrowser/FileBrowser.swift
@@ -55,7 +55,12 @@ open class FileBrowser: UINavigationController {
      - returns: File browser view controller.
      */
     public convenience init(initialPath: URL) {
+        self.init(initialPath: initialPath, allowEditing: false)
+    }
+    
+    public convenience init(initialPath: URL, allowEditing: Bool) {
         let fileListViewController = FileListViewController(initialPath: initialPath)
+        fileListViewController.allowEditing = allowEditing
         self.init(rootViewController: fileListViewController)
         self.view.backgroundColor = UIColor.white
         self.fileList = fileListViewController

--- a/FileBrowser/FileBrowser.swift
+++ b/FileBrowser/FileBrowser.swift
@@ -59,7 +59,11 @@ open class FileBrowser: UINavigationController {
     }
     
     public convenience init(initialPath: URL, allowEditing: Bool) {
-        let fileListViewController = FileListViewController(initialPath: initialPath)
+        self.init(initialPath: initialPath, allowEditing: allowEditing, showCancelButton: true)
+    }
+    
+    public convenience init(initialPath: URL, allowEditing: Bool, showCancelButton: Bool) {
+        let fileListViewController = FileListViewController(initialPath: initialPath, showCancelButton: showCancelButton)
         fileListViewController.allowEditing = allowEditing
         self.init(rootViewController: fileListViewController)
         self.view.backgroundColor = UIColor.white

--- a/FileBrowser/FileListTableView.swift
+++ b/FileBrowser/FileListTableView.swift
@@ -86,5 +86,19 @@ extension FileListViewController: UITableViewDataSource, UITableViewDelegate {
         return collation.section(forSectionIndexTitle: index)
     }
     
+    func tableView(_ tableView: UITableView, commit editingStyle: UITableViewCellEditingStyle, forRowAt indexPath: IndexPath) {
+        if (editingStyle == UITableViewCellEditingStyle.delete) {
+            let selectedFile = fileForIndexPath(indexPath)
+            selectedFile.delete()
+            
+            prepareData()
+            tableView.reloadSections([indexPath.section], with: UITableViewRowAnimation.automatic)
+        }
+    }
+    
+    func tableView(_ tableView: UITableView, canEditRowAt indexPath: IndexPath) -> Bool {
+        return allowEditing
+    }
+    
     
 }

--- a/FileBrowser/FileListViewController.swift
+++ b/FileBrowser/FileListViewController.swift
@@ -35,8 +35,11 @@ class FileListViewController: UIViewController {
     
     
     //MARK: Lifecycle
-    
     convenience init (initialPath: URL) {
+        self.init(initialPath: initialPath, showCancelButton: true)
+    }
+    
+    convenience init (initialPath: URL, showCancelButton: Bool) {
         self.init(nibName: "FileBrowser", bundle: Bundle(for: FileListViewController.self))
         self.edgesForExtendedLayout = UIRectEdge()
         
@@ -49,10 +52,11 @@ class FileListViewController: UIViewController {
         searchController.searchBar.delegate = self
         searchController.delegate = self
         
-        // Add dismiss button
-        let dismissButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(FileListViewController.dismiss(button:)))
-        self.navigationItem.rightBarButtonItem = dismissButton
-        
+        if showCancelButton {
+            // Add dismiss button
+            let dismissButton = UIBarButtonItem(barButtonSystemItem: .cancel, target: self, action: #selector(FileListViewController.dismiss(button:)))
+            self.navigationItem.rightBarButtonItem = dismissButton
+        }
     }
     
     deinit{

--- a/FileBrowser/FileListViewController.swift
+++ b/FileBrowser/FileListViewController.swift
@@ -21,6 +21,7 @@ class FileListViewController: UIViewController {
     let parser = FileParser.sharedInstance
     let previewManager = PreviewManager()
     var sections: [[FBFile]] = []
+    var allowEditing: Bool = false
 
     // Search controller
     var filteredFiles = [FBFile]()
@@ -62,15 +63,19 @@ class FileListViewController: UIViewController {
         }
     }
     
-    //MARK: UIViewController
-    
-    override func viewDidLoad() {
-        
+    func prepareData() {
         // Prepare data
         if let initialPath = initialPath {
             files = parser.filesForDirectory(initialPath)
             indexFiles()
         }
+    }
+    
+    //MARK: UIViewController
+    
+    override func viewDidLoad() {
+        
+        prepareData()
         
         // Set search bar
         tableView.tableHeaderView = searchController.searchBar

--- a/examples/Sample/Sample/Assets.xcassets/AppIcon.appiconset/Contents.json
+++ b/examples/Sample/Sample/Assets.xcassets/AppIcon.appiconset/Contents.json
@@ -2,6 +2,16 @@
   "images" : [
     {
       "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "iphone",
+      "size" : "20x20",
+      "scale" : "3x"
+    },
+    {
+      "idiom" : "iphone",
       "size" : "29x29",
       "scale" : "2x"
     },
@@ -32,6 +42,16 @@
     },
     {
       "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "1x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "20x20",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
       "size" : "29x29",
       "scale" : "1x"
     },
@@ -58,6 +78,11 @@
     {
       "idiom" : "ipad",
       "size" : "76x76",
+      "scale" : "2x"
+    },
+    {
+      "idiom" : "ipad",
+      "size" : "83.5x83.5",
       "scale" : "2x"
     }
   ],


### PR DESCRIPTION
By specifying a boolean in a new custom init method, it passes along a boolean into the FileListViewController which in turn set allowEditing on the tableView.  Where I'm not sure things are going to be super smooth is re-parsing of the files and storage variables in the tableView's commit editing style delegate method.  In a future version, this might need to be done on a background thread with an activity view display.